### PR TITLE
Es/revamp context

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -17,7 +17,7 @@ API reference
 
 .. autofunction:: cli
 
-.. autoclass:: BakerDriver
+.. autoclass:: BakerDriverContext
 
 
 :mod:`tinybaker.fileref`

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -17,7 +17,7 @@ API reference
 
 .. autofunction:: cli
 
-.. autoclass:: BakerContext
+.. autoclass:: BakerDriver
 
 
 :mod:`tinybaker.fileref`

--- a/tests/fast/test_merge.py
+++ b/tests/fast/test_merge.py
@@ -1,4 +1,4 @@
-from tinybaker import sequence, merge, Transform, BakerDriver, map_tags
+from tinybaker import sequence, merge, Transform, BakerDriverContext, map_tags
 from tinybaker.exceptions import TagConflictError
 import pytest
 
@@ -136,7 +136,7 @@ def test_multiprocessed_merge():
 
     Merged = merge([MP_StepOne, MP_StepTwo])
 
-    BakerDriver(
+    BakerDriverContext(
         parallel_mode="multiprocessing", fs_for_intermediates="nvtemp"
     ).run(
         Merged(
@@ -171,7 +171,7 @@ def test_not_parallel_merge():
 
     Merged = merge([StepOne, StepTwo])
 
-    BakerDriver(parallel_mode=None).run(
+    BakerDriverContext(parallel_mode=None).run(
         Merged(
             input_paths={
                 "foo": "./tests/__data__/foo.txt",

--- a/tests/fast/test_merge.py
+++ b/tests/fast/test_merge.py
@@ -1,4 +1,4 @@
-from tinybaker import sequence, merge, Transform, BakerContext, map_tags
+from tinybaker import sequence, merge, Transform, BakerDriver, map_tags
 from tinybaker.exceptions import TagConflictError
 import pytest
 
@@ -136,17 +136,18 @@ def test_multiprocessed_merge():
 
     Merged = merge([MP_StepOne, MP_StepTwo])
 
-    Merged(
-        input_paths={
-            "foo": "./tests/__data__/foo.txt",
-            "bloop": "./tests/__data__/bloop.txt",
-        },
-        output_paths={"bar": "/tmp/bar", "bleep": "/tmp/bleep"},
-        overwrite=True,
-        context=BakerContext(
-            parallel_mode="multiprocessing", fs_for_intermediates="nvtemp"
-        ),
-    ).run()
+    BakerDriver(
+        parallel_mode="multiprocessing", fs_for_intermediates="nvtemp"
+    ).run_transform(
+        Merged(
+            input_paths={
+                "foo": "./tests/__data__/foo.txt",
+                "bloop": "./tests/__data__/bloop.txt",
+            },
+            output_paths={"bar": "/tmp/bar", "bleep": "/tmp/bleep"},
+            overwrite=True,
+        )
+    )
 
     with open("/tmp/bar", "r") as f:
         assert f.read() == "foo contents processed"
@@ -170,15 +171,16 @@ def test_not_parallel_merge():
 
     Merged = merge([StepOne, StepTwo])
 
-    Merged(
-        input_paths={
-            "foo": "./tests/__data__/foo.txt",
-            "bloop": "./tests/__data__/bloop.txt",
-        },
-        output_paths={"bar": "/tmp/bar", "bleep": "/tmp/bleep"},
-        overwrite=True,
-        context=BakerContext(parallel_mode=None),
-    ).run()
+    BakerDriver(parallel_mode=None).run_transform(
+        Merged(
+            input_paths={
+                "foo": "./tests/__data__/foo.txt",
+                "bloop": "./tests/__data__/bloop.txt",
+            },
+            output_paths={"bar": "/tmp/bar", "bleep": "/tmp/bleep"},
+            overwrite=True,
+        )
+    )
 
     with open("/tmp/bar", "r") as f:
         assert f.read() == "foo contents processed"

--- a/tests/fast/test_merge.py
+++ b/tests/fast/test_merge.py
@@ -138,7 +138,7 @@ def test_multiprocessed_merge():
 
     BakerDriver(
         parallel_mode="multiprocessing", fs_for_intermediates="nvtemp"
-    ).run_transform(
+    ).run(
         Merged(
             input_paths={
                 "foo": "./tests/__data__/foo.txt",
@@ -171,7 +171,7 @@ def test_not_parallel_merge():
 
     Merged = merge([StepOne, StepTwo])
 
-    BakerDriver(parallel_mode=None).run_transform(
+    BakerDriver(parallel_mode=None).run(
         Merged(
             input_paths={
                 "foo": "./tests/__data__/foo.txt",

--- a/tests/fast/test_sequence.py
+++ b/tests/fast/test_sequence.py
@@ -1,6 +1,6 @@
 import pytest
 from tinybaker import sequence, Transform, InputTag, OutputTag
-from tinybaker.context import BakerDriver
+from tinybaker.context import BakerDriverContext
 
 
 def test_sequence():
@@ -53,7 +53,7 @@ def test_sequence():
 
 
 def test_in_memory_intermediates():
-    in_memory_context = BakerDriver(fs_for_intermediates="mem")
+    in_memory_context = BakerDriverContext(fs_for_intermediates="mem")
 
     class StepOne(Transform):
         foo = InputTag("foo")

--- a/tests/fast/test_sequence.py
+++ b/tests/fast/test_sequence.py
@@ -90,7 +90,7 @@ def test_in_memory_intermediates():
 
     Seq = sequence([StepOne, StepTwo, StepThree])
 
-    in_memory_context.run_transform(
+    in_memory_context.run(
         Seq(
             input_paths={
                 "foo": "./tests/__data__/foo.txt",

--- a/tests/fast/test_sequence.py
+++ b/tests/fast/test_sequence.py
@@ -1,6 +1,6 @@
 import pytest
 from tinybaker import sequence, Transform, InputTag, OutputTag
-from tinybaker.context import BakerContext
+from tinybaker.context import BakerDriver
 
 
 def test_sequence():
@@ -53,7 +53,7 @@ def test_sequence():
 
 
 def test_in_memory_intermediates():
-    in_memory_context = BakerContext(fs_for_intermediates="mem")
+    in_memory_context = BakerDriver(fs_for_intermediates="mem")
 
     class StepOne(Transform):
         foo = InputTag("foo")
@@ -90,15 +90,16 @@ def test_in_memory_intermediates():
 
     Seq = sequence([StepOne, StepTwo, StepThree])
 
-    Seq(
-        input_paths={
-            "foo": "./tests/__data__/foo.txt",
-            "bleep": "./tests/__data__/bleep.txt",
-        },
-        output_paths={"boppo": "/tmp/boppo"},
-        context=in_memory_context,
-        overwrite=True,
-    ).run()
+    in_memory_context.run_transform(
+        Seq(
+            input_paths={
+                "foo": "./tests/__data__/foo.txt",
+                "bleep": "./tests/__data__/bleep.txt",
+            },
+            output_paths={"boppo": "/tmp/boppo"},
+            overwrite=True,
+        )
+    )
 
     with open("/tmp/boppo", "r") as f:
         assert f.read() == "foo contents processed bleep contents"

--- a/tinybaker/__init__.py
+++ b/tinybaker/__init__.py
@@ -1,6 +1,6 @@
 from .transform import Transform
 from .combinators import sequence, merge, map_tags
 from .workarounds import fileset
-from .context import BakerDriver
+from .context import BakerDriverContext
 from .tag import InputTag, OutputTag
 from .cli import cli

--- a/tinybaker/__init__.py
+++ b/tinybaker/__init__.py
@@ -1,6 +1,6 @@
 from .transform import Transform
 from .combinators import sequence, merge, map_tags
 from .workarounds import fileset
-from .context import BakerContext
+from .context import BakerDriver
 from .tag import InputTag, OutputTag
 from .cli import cli

--- a/tinybaker/combinators/base.py
+++ b/tinybaker/combinators/base.py
@@ -21,7 +21,7 @@ class CombinatorBase(Transform, metaclass=CombinatorMeta):
 
     @classproperty
     def parallelism(cls):
-        max_parallelism = 1
+        max_parallelism = 0
         for step in cls.substeps:
             if step.parallelism > max_parallelism:
                 max_parallelism = step.parallelism

--- a/tinybaker/combinators/map.py
+++ b/tinybaker/combinators/map.py
@@ -137,10 +137,11 @@ def _create_tag_class(
                 self.output_files, _invert_mapping(self._output_mapping)
             )
             base_step = self._get_base_step()
-            base_step(
+            instance = base_step(
                 input_paths=input_paths,
                 output_paths=output_paths,
                 overwrite=self.overwrite,
-            )._exec_with_worker_context(self._current_worker_context)
+            )
+            self._current_worker_context.execute([instance])
 
     return TagMapping

--- a/tinybaker/combinators/map.py
+++ b/tinybaker/combinators/map.py
@@ -141,6 +141,6 @@ def _create_tag_class(
                 input_paths=input_paths,
                 output_paths=output_paths,
                 overwrite=self.overwrite,
-            )._exec_with_run_info(self._current_run_info)
+            )._exec_with_worker_context(self._current_worker_context)
 
     return TagMapping

--- a/tinybaker/combinators/map.py
+++ b/tinybaker/combinators/map.py
@@ -140,7 +140,6 @@ def _create_tag_class(
             base_step(
                 input_paths=input_paths,
                 output_paths=output_paths,
-                context=self.context,
                 overwrite=self.overwrite,
             )._exec_with_run_info(self._current_run_info)
 

--- a/tinybaker/combinators/merge.py
+++ b/tinybaker/combinators/merge.py
@@ -88,6 +88,6 @@ def _create_merge_class(merge_steps, merge_input_tags, merge_output_tags, merge_
                         overwrite=self.overwrite,
                     )
                 )
-            self._current_run_info.run_parallel(instances, self._current_run_info)
+            self._current_run_info.execute(instances)
 
     return Merged

--- a/tinybaker/combinators/merge.py
+++ b/tinybaker/combinators/merge.py
@@ -88,6 +88,6 @@ def _create_merge_class(merge_steps, merge_input_tags, merge_output_tags, merge_
                         overwrite=self.overwrite,
                     )
                 )
-            self._current_run_info.execute(instances)
+            self._current_worker_context.execute(instances)
 
     return Merged

--- a/tinybaker/combinators/merge.py
+++ b/tinybaker/combinators/merge.py
@@ -85,10 +85,9 @@ def _create_merge_class(merge_steps, merge_input_tags, merge_output_tags, merge_
                     step(
                         input_files,
                         output_files,
-                        context=self.context,
                         overwrite=self.overwrite,
                     )
                 )
-            self.context.run_parallel(instances, self._current_run_info)
+            self._current_run_info.run_parallel(instances, self._current_run_info)
 
     return Merged

--- a/tinybaker/combinators/sequence.py
+++ b/tinybaker/combinators/sequence.py
@@ -157,7 +157,7 @@ def _build_sequence_class(seq_input_tags, seq_output_tags, seq_steps, seq_name):
 
             # Phase 2: Run instances
             for instance in instances:
-                instance._exec_with_worker_context(self._current_worker_context)
+                self._current_worker_context.execute([instance])
 
     return Sequence
 

--- a/tinybaker/combinators/sequence.py
+++ b/tinybaker/combinators/sequence.py
@@ -80,7 +80,7 @@ def _build_sequence_class(seq_input_tags, seq_output_tags, seq_steps, seq_name):
         _name = seq_name
 
         def _generate_temp_filename(self, sid):
-            target_fs = self.context.fs_for_intermediates
+            target_fs = self._current_run_info.baker_config.fs_for_intermediates
             return "{}://tinybaker-{}__{}".format(target_fs, sid, uuid4())
 
         @classmethod
@@ -148,7 +148,6 @@ def _build_sequence_class(seq_input_tags, seq_output_tags, seq_steps, seq_name):
                     step(
                         input_paths=input_paths,
                         output_paths=output_paths,
-                        context=self.context,
                         overwrite=self.overwrite,
                     )
                 )

--- a/tinybaker/combinators/sequence.py
+++ b/tinybaker/combinators/sequence.py
@@ -80,7 +80,7 @@ def _build_sequence_class(seq_input_tags, seq_output_tags, seq_steps, seq_name):
         _name = seq_name
 
         def _generate_temp_filename(self, sid):
-            target_fs = self._current_run_info.baker_config.fs_for_intermediates
+            target_fs = self._current_worker_context.baker_config.fs_for_intermediates
             return "{}://tinybaker-{}__{}".format(target_fs, sid, uuid4())
 
         @classmethod
@@ -157,7 +157,7 @@ def _build_sequence_class(seq_input_tags, seq_output_tags, seq_steps, seq_name):
 
             # Phase 2: Run instances
             for instance in instances:
-                instance._exec_with_run_info(self._current_run_info)
+                instance._exec_with_worker_context(self._current_worker_context)
 
     return Sequence
 

--- a/tinybaker/context.py
+++ b/tinybaker/context.py
@@ -48,7 +48,7 @@ class BakerWorkerContext:
         return (BakerWorkerContext, (self.baker_config, self.parallelizer))
 
 
-class BakerDriver:
+class BakerDriverContext:
     """
     Driver Context for running TinyBaker transforms
 
@@ -94,7 +94,7 @@ class BakerDriver:
         raise NotImplementedError("Should not serialize and share driver object!")
 
 
-_default_context = BakerDriver()
+_default_context = BakerDriverContext()
 
 
 def get_default_context():

--- a/tinybaker/context.py
+++ b/tinybaker/context.py
@@ -79,9 +79,9 @@ class BakerDriver:
         )
 
     def run(self, transform):
-        run_info = BakerWorkerContext(self.baker_config)
-        with run_info:
-            run_info.execute([transform])
+        worker_context = BakerWorkerContext(self.baker_config)
+        with worker_context:
+            worker_context.execute([transform])
 
     def __reduce__(self):
         raise NotImplementedError("Should not serialize and share driver object!")

--- a/tinybaker/context.py
+++ b/tinybaker/context.py
@@ -4,11 +4,18 @@ from fs.osfs import OSFS
 from .exceptions import BakerError
 from .workarounds import is_fileset
 from .parallel import ProcessParallelizer, ThreadParallelizer, NonParallelizer
+from collections import namedtuple
+
+BakerConfig = namedtuple(
+    "BakerConfig",
+    ["fs_for_intermediates", "parallel_mode", "max_threads", "max_processes"],
+)
 
 
 class RunInfo:
-    def __init__(self):
+    def __init__(self, baker_config: BakerConfig):
         self.open_fses = {}
+        self.baker_config = baker_config
 
     def __enter__(self):
         self.open_fses = {
@@ -22,17 +29,28 @@ class RunInfo:
             fs = self.open_fses[prefix]
             fs.close()
 
+    def run_parallel(self, instances, run_info):
+        parallel_mode = self.baker_config.parallel_mode
+        # TODO: Make the parallelizer live longer-term than just within this call
+        if parallel_mode == "multiprocessing":
+            par = ProcessParallelizer()
+        elif parallel_mode == "multithreading":
+            par = ThreadParallelizer()
+        else:
+            par = NonParallelizer()
+        return par.run_parallel(instances, run_info)
+
     # This defines what's shared between processes. Right now, the
     # answer is "nothing", which we can get away with due to requiring
     # nvtemp:// for multiprocessing.
     def __reduce__(self):
-        return (RunInfo, ())
+        return (RunInfo, (self.baker_config,))
 
 
 # TODO: This should probably exist only in the driver side.
-class BakerContext:
+class BakerDriver:
     """
-    Execution Context for running TinyBaker transforms
+    Driver Context for running TinyBaker transforms
 
     :param optional fs_for_intermediates:
         Which filesystem to use to store intermediates. You probably want this to be "temp" or "mem"
@@ -49,35 +67,23 @@ class BakerContext:
         max_processes=8,
         parallel_mode="multithreading",
     ):
-        self.fs_for_intermediates = fs_for_intermediates
-        self.max_threads = max_threads
-        self.max_processes = max_processes
-        self.parallel_mode = parallel_mode
-
         # If we're using multiprocessing, we HAVE to use nvtemp filesystem
         # for intermediates. This is until i get better at stuff.
         if parallel_mode == "multiprocessing" and fs_for_intermediates != "nvtemp":
             raise BakerError(
                 "Multiprocessing requires fs_for_intermediates of nvtemp (for nonvolatile temp)"
             )
+        self.baker_config = BakerConfig(
+            fs_for_intermediates, parallel_mode, max_threads, max_processes
+        )
 
     def run_transform(self, transform):
-        run_info = RunInfo()
+        run_info = RunInfo(self.baker_config)
         with run_info:
             transform._exec_with_run_info(run_info)
 
-    def run_parallel(self, instances, run_info):
-        # TODO: Make the parallelizer live longer-term than just within this call
-        if self.parallel_mode == "multiprocessing":
-            par = ProcessParallelizer()
-        elif self.parallel_mode == "multithreading":
-            par = ThreadParallelizer()
-        else:
-            par = NonParallelizer()
-        return par.run_parallel(self, instances, run_info)
 
-
-_default_context = BakerContext()
+_default_context = BakerDriver()
 
 
 def get_default_context():

--- a/tinybaker/context.py
+++ b/tinybaker/context.py
@@ -47,7 +47,6 @@ class RunInfo:
         return (RunInfo, (self.baker_config,))
 
 
-# TODO: This should probably exist only in the driver side.
 class BakerDriver:
     """
     Driver Context for running TinyBaker transforms
@@ -77,10 +76,13 @@ class BakerDriver:
             fs_for_intermediates, parallel_mode, max_threads, max_processes
         )
 
-    def run_transform(self, transform):
+    def run(self, transform):
         run_info = RunInfo(self.baker_config)
         with run_info:
             transform._exec_with_run_info(run_info)
+
+    def __reduce__(self):
+        raise NotImplementedError("Should not serialize and share driver object!")
 
 
 _default_context = BakerDriver()

--- a/tinybaker/fileref.py
+++ b/tinybaker/fileref.py
@@ -26,12 +26,12 @@ def get_truncated_path(path, fname):
 class FileRef:
     """Represents a reference to a file. TinyBaker generates these for use in the script() function"""
 
-    def __init__(self, path, read_bit, write_bit, run_info):
+    def __init__(self, path, read_bit, write_bit, worker_context):
         self.path = path
         self._read = read_bit
         self._write = write_bit
         self.opened = False
-        self.run_info = run_info
+        self.worker_context = worker_context
 
     def exists(self) -> bool:
         """
@@ -103,10 +103,10 @@ class FileRef:
     def _get_fs_and_path(self):
         # Annoyingly, relative dirs are not parsed well by parse_fs_url
         protocol = self._get_protocol()
-        if protocol in self.run_info.open_fses:
+        if protocol in self.worker_context.open_fses:
             # pre-opened case
             parsed = parse_fs_url(self.path)
-            fs = self.run_info.open_fses[protocol]
+            fs = self.worker_context.open_fses[protocol]
             fname = parsed.resource
             should_close = False
         else:

--- a/tinybaker/parallel.py
+++ b/tinybaker/parallel.py
@@ -6,7 +6,7 @@ from queue import Queue
 
 class ParalellizerBase(ABC):
     @abstractmethod
-    def run_parallel(self, instances, current_run_info):
+    def run_parallel(self, instances, current_worker_context):
         pass
 
     def __reduce__(self):
@@ -21,39 +21,43 @@ class ThreadParallelizer(ParalellizerBase):
 
         def run(self):
             while True:
-                instance, run_info = self.queue.get()
+                instance, worker_context = self.queue.get()
                 try:
-                    instance._exec_with_run_info(run_info)
+                    instance._exec_with_worker_context(worker_context)
                 finally:
                     self.queue.task_done()
 
-    def run_parallel(self, instances, current_run_info):
+    def run_parallel(self, instances, current_worker_context):
         queue = Queue()
-        parallelism = min(len(instances), current_run_info.baker_config.max_threads)
+        parallelism = min(
+            len(instances), current_worker_context.baker_config.max_threads
+        )
         for _ in range(parallelism):
             worker = ThreadParallelizer.ParallelWorker(queue)
             worker.daemon = True
             worker.start()
 
         for instance in instances:
-            queue.put((instance, current_run_info))
+            queue.put((instance, current_worker_context))
         queue.join()
 
 
 class ProcessParallelizer(ParalellizerBase):
     @staticmethod
     def _mp_run(arg):
-        instance, current_run_info = arg
-        return instance._exec_with_run_info(current_run_info)
+        instance, current_worker_context = arg
+        return instance._exec_with_worker_context(current_worker_context)
 
-    def run_parallel(self, instances, current_run_info):
-        parallelism = min(len(instances), current_run_info.baker_config.max_processes)
+    def run_parallel(self, instances, current_worker_context):
+        parallelism = min(
+            len(instances), current_worker_context.baker_config.max_processes
+        )
         with Pool(parallelism) as pool:
-            mp_args = [(instance, current_run_info) for instance in instances]
+            mp_args = [(instance, current_worker_context) for instance in instances]
             pool.map(self._mp_run, mp_args)
 
 
 class NonParallelizer(ParalellizerBase):
-    def run_parallel(self, instances, current_run_info):
+    def run_parallel(self, instances, current_worker_context):
         for instance in instances:
-            instance._exec_with_run_info(current_run_info)
+            instance._exec_with_worker_context(current_worker_context)

--- a/tinybaker/parallel.py
+++ b/tinybaker/parallel.py
@@ -4,16 +4,13 @@ from multiprocessing import Pool
 from queue import Queue
 
 
-class ParalellizerBase(ABC):
+class BaseParallelizer(ABC):
     @abstractmethod
     def run_parallel(self, instances, current_worker_context):
         pass
 
-    def __reduce__(self):
-        raise NotImplementedError("We really shouldn't be pickling parallelizers")
 
-
-class ThreadParallelizer(ParalellizerBase):
+class ThreadParallelizer(BaseParallelizer):
     class ParallelWorker(Thread):
         def __init__(self, queue):
             Thread.__init__(self)
@@ -42,7 +39,7 @@ class ThreadParallelizer(ParalellizerBase):
         queue.join()
 
 
-class ProcessParallelizer(ParalellizerBase):
+class ProcessParallelizer(BaseParallelizer):
     @staticmethod
     def _mp_run(arg):
         instance, current_worker_context = arg
@@ -57,7 +54,7 @@ class ProcessParallelizer(ParalellizerBase):
             pool.map(self._mp_run, mp_args)
 
 
-class NonParallelizer(ParalellizerBase):
+class NonParallelizer(BaseParallelizer):
     def run_parallel(self, instances, current_worker_context):
         for instance in instances:
             instance._exec_with_worker_context(current_worker_context)

--- a/tinybaker/transform.py
+++ b/tinybaker/transform.py
@@ -11,7 +11,7 @@ from .exceptions import (
     ConfigurationError,
     UnusedFileWarning,
 )
-from .context import BakerContext, get_default_context
+from .context import BakerDriver, get_default_context
 from .util import get_files_in_path_dict, classproperty
 from typeguard import typechecked
 from .namespace_transforms import namespace_to_transform, dict_to_transform
@@ -44,7 +44,7 @@ class Transform(metaclass=TransformMeta):
 
     :param input_paths: Dictionary of input tags to files.
     :param output_paths: Dictionary of output tags to files.
-    :param optional context: The BakerContext to use for this transformation
+    :param optional context: The BakerDriver to use for this transformation
     :param optional overwrite: Whether or not to configure the transformation to overwrite output files on execution
     """
 
@@ -76,7 +76,6 @@ class Transform(metaclass=TransformMeta):
         self,
         input_paths: PathDict,
         output_paths: PathDict,
-        context: BakerContext = get_default_context(),
         overwrite: bool = False,
     ):
         _ensure_fileset_iff_fileset_tag(input_paths)
@@ -87,7 +86,6 @@ class Transform(metaclass=TransformMeta):
 
         self.input_files: FileDict = {}
         self.output_files: FileDict = {}
-        self.context = context
         self.overwrite = overwrite
         self._current_run_info = None
 
@@ -228,8 +226,8 @@ class Transform(metaclass=TransformMeta):
         return cls.__name__
 
     def run(self):
-        """Run the transform instance"""
-        self.context.run_transform(self)
+        """Run the transform instance in the default context"""
+        get_default_context().run_transform(self)
 
     def _exec_with_run_info(self, run_info):
         # Set

--- a/tinybaker/transform.py
+++ b/tinybaker/transform.py
@@ -227,7 +227,7 @@ class Transform(metaclass=TransformMeta):
 
     def run(self):
         """Run the transform instance in the default context"""
-        get_default_context().run_transform(self)
+        get_default_context().run(self)
 
     def _exec_with_run_info(self, run_info):
         # Set

--- a/tinybaker/transform.py
+++ b/tinybaker/transform.py
@@ -11,7 +11,7 @@ from .exceptions import (
     ConfigurationError,
     UnusedFileWarning,
 )
-from .context import BakerDriver, get_default_context
+from .context import BakerDriverContext, get_default_context
 from .util import get_files_in_path_dict, classproperty
 from typeguard import typechecked
 from .namespace_transforms import namespace_to_transform, dict_to_transform
@@ -44,7 +44,7 @@ class Transform(metaclass=TransformMeta):
 
     :param input_paths: Dictionary of input tags to files.
     :param output_paths: Dictionary of output tags to files.
-    :param optional context: The BakerDriver to use for this transformation
+    :param optional context: The BakerDriverContext to use for this transformation
     :param optional overwrite: Whether or not to configure the transformation to overwrite output files on execution
     """
 

--- a/tinybaker/transform.py
+++ b/tinybaker/transform.py
@@ -87,7 +87,7 @@ class Transform(metaclass=TransformMeta):
         self.input_files: FileDict = {}
         self.output_files: FileDict = {}
         self.overwrite = overwrite
-        self._current_run_info = None
+        self._current_worker_context = None
 
     @classproperty
     def input_tags(cls):
@@ -132,7 +132,7 @@ class Transform(metaclass=TransformMeta):
                             individual_path,
                             read_bit=True,
                             write_bit=False,
-                            run_info=self._current_run_info,
+                            worker_context=self._current_worker_context,
                         )
                     )
                 self.input_files[tag] = refset
@@ -141,7 +141,7 @@ class Transform(metaclass=TransformMeta):
                     input_paths[tag],
                     read_bit=True,
                     write_bit=False,
-                    run_info=self._current_run_info,
+                    worker_context=self._current_worker_context,
                 )
 
         for tag in output_paths:
@@ -153,7 +153,7 @@ class Transform(metaclass=TransformMeta):
                             individual_path,
                             read_bit=False,
                             write_bit=True,
-                            run_info=self._current_run_info,
+                            worker_context=self._current_worker_context,
                         )
                     )
                 self.output_files[tag] = refset
@@ -162,7 +162,7 @@ class Transform(metaclass=TransformMeta):
                     output_paths[tag],
                     read_bit=False,
                     write_bit=True,
-                    run_info=self._current_run_info,
+                    worker_context=self._current_worker_context,
                 )
 
     def _validate_file_existence(self):
@@ -229,17 +229,17 @@ class Transform(metaclass=TransformMeta):
         """Run the transform instance in the default context"""
         get_default_context().run(self)
 
-    def _exec_with_run_info(self, run_info):
+    def _exec_with_worker_context(self, worker_context):
         # Set
         input_token = input_files_ctx.set(self.input_files)
         output_token = output_files_ctx.set(self.output_files)
         try:
-            self._current_run_info = run_info
+            self._current_worker_context = worker_context
             self._init_file_dicts(self.input_paths, self.output_paths)
             self._validate_file_existence()
-            if not run_info:
+            if not worker_context:
                 raise SeriousErrorThatYouShouldOpenAnIssueForIfYouGet(
-                    "No current run information, somehow!"
+                    "No current worker context, somehow!"
                 )
             self.script()
             self._warn_if_files_untouched()


### PR DESCRIPTION
RunInfo -> BakerWorkerContext, replicated across all processes.
BakerContext -> BakerDriverContext, only on parent / driver process.

Decoupled non-worker contexts from transforms.